### PR TITLE
freeze pynndescent to last working version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ packages = [{include = "neofuzz"}]
 [tool.poetry.dependencies]
 python = ">=3.8"
 scikit-learn = ">=1.1.0, <1.6.0"
-pynndescent = ">=0.5.0, <0.6.0"
+pynndescent = "0.5.12"
 numpy = ">=0.22.0, <2.0.0"
 tokenizers = ">=0.19.0, <0.20.0"
 joblib = ">=1.4.0, <1.5.0"


### PR DESCRIPTION
freezes pynndescent to 0.5.12 which is the latest working version. 0.5.13 is available but unable to correctlly load dumped models (https://github.com/lmcinnes/pynndescent/issues/247)